### PR TITLE
feat:docker-compose调整

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,32 @@
+# Bing search key
+BING_SEARCH_KEY=
+# Google search key
+GOOGLE_SEARCH_KEY=
+GOOGLE_SEARCH_ID=
+# aliyun key
+ALIYUN_KEY=
+# Yi Key
+YI_KEY=
+# google gemini
+GOOGLE_KEY=
+GOOGLE_PROXY_URL=
+# baidu
+BAIDU_KEY=
+BAIDU_SECRET=
+# tencent KEY:ID, SECRET:KEY
+TENCENT_KEY=
+TENCENT_SECRET=
+# openai key
+OPENAI_KEY=freeduckduckgo
+# openai proxy, default is for docker-compose, could modify if you need.
+OPENAI_PROXY_URL=http://freeduckduckgo:3456/v1
+# moonshot
+MOONSHOT_KEY=
+# lepthon key
+LEPTON_KEY=
+# Local llm: Ollama hostname, could modify if you need.
+OLLAMA_HOST=http://host.docker.internal:11434
+# Searxng hostname, could modify if you need.
+SEARXNG_HOSTNAME=http://searxng:8080
+# The count of resources referenced
+REFERENCE_COUNT = 8

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,18 @@ services:
   search:
     build: ./
     container_name: search
+    volumes:
+      - ./.env.docker:/app/.env
     ports:
       - "3000:3000"
     restart: always
 
-  freegpt35:
-    container_name: freegpt35
-    image: missuo/freegpt35:latest
+  freeduckduckgo:
+    image: ghcr.io/missuo/freeduckduckgo:latest
+    container_name: freeduckduckgo
     restart: always
+    #ports:
+    #  - "3456:3456"
 
   searxng:
     container_name: searxng


### PR DESCRIPTION
1. freegpt35项目目前不可用，用freeduckduckgo替换
2. 项目默认将.env打包进了容器，导致修改.env文件重启容器不生效，在docker-compose.yml增加.env文件映射
