### PR TITLE
fix(config): fix model name parsing

### DIFF
--- a/apps/server/src/libs/provider/base/openai.ts
+++ b/apps/server/src/libs/provider/base/openai.ts
@@ -44,7 +44,7 @@ export class BaseOpenAIChat implements BaseChat {
     if (typeof onMessage === 'function') {
       const stream = await this.openai.chat.completions.create({
         messages,
-        model,
+        model: model.toString(),
         stream: true,
         temperature
       });
@@ -71,7 +71,7 @@ export class BaseOpenAIChat implements BaseChat {
 
     const res = await this.openai.chat.completions.create({
       messages,
-      model,
+      model: model.toString(),
       temperature
     });
     return {

--- a/apps/web/src/pages/components/chat.vue
+++ b/apps/web/src/pages/components/chat.vue
@@ -96,8 +96,9 @@ async function startChat() {
   abortCtrl = ctrl;
   loading.value = true;
   const { model } = appStore;
-  const provider = model?.split(':')[0];
-  const modelName = model?.split(':')[1];
+  // Split only on the first colon to preserve subsequent colons in model name
+  const [provider, ...modelParts] = model?.split(':') || [];
+  const modelName = modelParts.join(':');
   messages.value.push({
     role: 'assistant',
     content: '',


### PR DESCRIPTION
**Title:** 

Fix model name parsing to prevent model names being incorrectly passed to Ollama

**Description:** (optional)

- Ensure we pass the model names exactly as defined to the LLM server

**Motivation:** (optional)

<img width="965" alt="image" src="https://github.com/user-attachments/assets/dff08586-4af7-42bc-ab60-9c73cbab55f5" />

Currently when you provide a model name, the application truncates the model name and removes anything after the `:`.

For example, if you set the model name:

```json
[
  {
    "provider": "ollama",
    "type": "openai",
    "baseURL": "http://ollama:11434/v1",
    "models": [
      "qwen2.5-32b-instruct:Q6_K_L",
    ]
  }
]

```

The app will error as it cuts off part of the model name:

```
[LLM Error]: NotFoundError: 404 model "qwen2.5-32b-instruct" not found, try pulling it first
    at APIError.generate (/app/node_modules/openai/error.js:54:20)
    at OpenAI.makeStatusError (/app/node_modules/openai/core.js:293:33)
    at OpenAI.makeRequest (/app/node_modules/openai/core.js:337:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async BaseOpenAIChat.chat (/app/dist/libs/provider/base/openai.js:61:21)
    at async Rag.getRelatedQuestions (/app/dist/service/rag/index.js:112:25)
    at async Rag.query (/app/dist/service/rag/index.js:98:25)
    at async searchController (/app/dist/controller.js:55:5)
    at async /app/dist/middleware.js:11:20
    at async /app/dist/app.js:37:9 {
  status: 404,
  headers: {
    'content-length': '131',
    'content-type': 'application/json',
    date: 'Tue, 04 Feb 2025 06:26:21 GMT'
  },
  request_id: undefined,
  error: {
    message: 'model "qwen2.5-32b-instruct" not found, try pulling it first',   <<< This is wrong
    type: 'api_error',
    param: null,
    code: null
  },
  code: null,
  param: null,
  type: 'api_error'
}
```

## Issue

https://github.com/yokingma/search_with_ai/issues/100