### PR TITLE
优化 Dockerfile

### DIFF
--- a/.devops/Dockerfile
+++ b/.devops/Dockerfile
@@ -36,6 +36,7 @@ RUN apk add --no-cache curl && curl -fsS https://dotenvx.sh/ | sh
 WORKDIR /app
 
 COPY --from=build /apps/server/package.json ./
+COPY --from=build /apps/server/yarn.lock ./
 
 RUN yarn install --production --frozen-lockfile && \
   yarn cache clean && \

--- a/.devops/Dockerfile
+++ b/.devops/Dockerfile
@@ -1,38 +1,49 @@
-FROM node:20 AS build
+FROM node:20-alpine AS base
 
-WORKDIR /apps
-
-COPY ../apps .
-
-# RUN yarn config set registry https://mirrors.cloud.tencent.com/npm/
-
-RUN apt-get update && apt-get install -y python3 make g++
-
-WORKDIR /apps/server
-RUN yarn install && yarn run build
-
-WORKDIR /apps/web
-RUN yarn install && yarn run build
-
-FROM node:20-alpine AS production
-
-WORKDIR /app
-
-# 安装 curl，下载并安装 dotenvx，然后删除 curl
-RUN apk add --no-cache curl && \
-    curl -fsS https://dotenvx.sh/ | sh
+FROM base AS build
 
 RUN apk add --no-cache python3 make g++
 
-COPY --from=build /apps/server/dist ./dist
-COPY --from=build /apps/server/.env ./
-COPY --from=build /apps/server/package.json ./
-COPY --from=build /apps/web/dist ./web/dist
+# RUN yarn config set registry https://mirrors.cloud.tencent.com/npm/
+
+WORKDIR /apps
+
+COPY ../apps/web/package.json ./web/
+COPY ../apps/server/package.json ./server/
+
+WORKDIR /apps/web
+RUN yarn install
+
+WORKDIR /apps/server
+RUN yarn install
+
+WORKDIR /apps/web
+COPY ../apps/web ./
+RUN yarn run build
+
+WORKDIR /apps/server
+COPY ../apps/server ./
+RUN yarn run build
+
+
+FROM base AS production
+
+RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache curl && curl -fsS https://dotenvx.sh/ | sh
 
 # RUN yarn config set registry https://mirrors.cloud.tencent.com/npm/
+
+WORKDIR /app
+
+COPY --from=build /apps/server/package.json ./
+
 RUN yarn install --production --frozen-lockfile && \
   yarn cache clean && \
   apk del curl python3 make g++
+
+COPY --from=build /apps/server/dist ./dist
+COPY --from=build /apps/server/.env ./
+COPY --from=build /apps/web/dist ./web/dist
 
 EXPOSE 3000
 CMD ["yarn", "run", "start"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+Dockerfile
+.dockerignore
+
+**/node_modules
+**/dist
+**/.turbo
+**/.yarn
+
+**/.env.local
+
+.git


### PR DESCRIPTION
**Title:** 
- 优化：`Dockerfile`

**Description:**
- 添加 `.dockerignore`，排除本地构建/调试镜像时部分文件的干扰；
- `Dockerfile` 文件调整内容：
  - 构建过程和运行时的基础镜像统一为 `node:20-alpine`
  - 调整部分文件处理、命令执行的顺序，以尽可能复用构建缓存

**Motivation:**
- 优化/减少构建耗时

**Related Issues:**
- none

**其他：**
- 我在本地调试和测试的时候没有发现不安装 `python3 make g++` 这几个依赖也能跑
- 同样的，命令显式安装 `dotenvx` 我去掉后也能跑（项目依赖中已经装了）
- 基于我对项目不够熟悉，上述依赖的处理保留，仅调整了指令流程

> registry 对构建速度有一定影响，使用时注意换源